### PR TITLE
tok: allow uppercase hex digits in string constants

### DIFF
--- a/tok.c
+++ b/tok.c
@@ -52,7 +52,7 @@ static int esc_char(int *c, char *s)
 			base = 16;
 			i++;
 		}
-		while ((d = memchr(digs, s[i], base))) {
+		while ((d = memchr(digs, tolower(s[i]), base))) {
 			ret *= base;
 			ret += d - digs;
 			i++;


### PR DESCRIPTION
E.g. '\x1B' is the same as '\x1b'.